### PR TITLE
Add -unique flag for ignoring duplicate messages per meter.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ data
 scm/Makefile
 release.7z
 *.diff
+desktop.ini
+*~

--- a/flags.go
+++ b/flags.go
@@ -46,6 +46,7 @@ var decimation = flag.Int("decimation", 1, "integer decimation factor, keep ever
 var timeLimit = flag.Duration("duration", 0, "time to run for, 0 for infinite, ex. 1h5m10s")
 var meterID UintMap
 var meterType UintMap
+var unique = flag.Bool("unique", false, "do not print duplicate values from each meter")
 
 var encoder Encoder
 var format = flag.String("format", "plain", "format to write log messages in: plain, csv, json, xml or gob")
@@ -73,6 +74,7 @@ func RegisterFlags() {
 		"format":       true,
 		"gobunsafe":    true,
 		"quiet":        true,
+		"unique":       true,
 		"single":       true,
 		"cpuprofile":   true,
 		"fastmag":      true,

--- a/flags.go
+++ b/flags.go
@@ -46,7 +46,7 @@ var decimation = flag.Int("decimation", 1, "integer decimation factor, keep ever
 var timeLimit = flag.Duration("duration", 0, "time to run for, 0 for infinite, ex. 1h5m10s")
 var meterID UintMap
 var meterType UintMap
-var unique = flag.Bool("unique", false, "do not print duplicate values from each meter")
+var unique = flag.Bool("unique", false, "do not print duplicate messages from each meter")
 
 var encoder Encoder
 var format = flag.String("format", "plain", "format to write log messages in: plain, csv, json, xml or gob")

--- a/idm/idm.go
+++ b/idm/idm.go
@@ -163,6 +163,11 @@ func (idm IDM) MeterType() uint8 {
 	return idm.ERTType
 }
 
+func (idm IDM) MeterValue() uint32 {
+	// don't know yet
+	return 0
+}
+
 func (idm IDM) String() string {
 	var fields []string
 

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -50,6 +50,7 @@ type Message interface {
 	MsgType() string
 	MeterID() uint32
 	MeterType() uint8
+	MeterValue() uint32
 }
 
 type LogMessage struct {

--- a/r900/r900.go
+++ b/r900/r900.go
@@ -253,6 +253,10 @@ func (r900 R900) MeterType() uint8 {
 	return r900.Unkn1
 }
 
+func (r900 R900) MeterValue() uint32 {
+	return r900.Consumption
+}
+
 func (r900 R900) String() string {
 	return fmt.Sprintf("{ID:%10d Unkn1:0x%02X NoUse:%2d BackFlow:%1d Consumption:%8d Unkn3:0x%02X Leak:%2d LeakNow:%1d}",
 		r900.ID,

--- a/recv.go
+++ b/recv.go
@@ -36,6 +36,7 @@ import (
 )
 
 var rcvr Receiver
+var lastValue map[uint]uint32
 
 type Receiver struct {
 	rtltcp.SDR
@@ -126,6 +127,7 @@ func (rcvr *Receiver) Run() {
 	}()
 
 	block := make([]byte, rcvr.p.Cfg().BlockSize2)
+	lastValue = make(map[uint]uint32)
 
 	start := time.Now()
 	for {
@@ -153,6 +155,12 @@ func (rcvr *Receiver) Run() {
 
 				if len(meterType) > 0 && !meterType[uint(pkt.MeterType())] {
 					continue
+				}
+				if *unique {
+					if lastValue[uint(pkt.MeterID())] == pkt.MeterValue() {
+						continue
+					}
+					lastValue[uint(pkt.MeterID())] = pkt.MeterValue()
 				}
 
 				var msg parse.LogMessage

--- a/recv.go
+++ b/recv.go
@@ -157,7 +157,7 @@ func (rcvr *Receiver) Run() {
 					continue
 				}
 				if *unique {
-					if lastValue[uint(pkt.MeterID())] == pkt.MeterValue() {
+					if val, ok := lastValue[uint(pkt.MeterID())]; ok && val == pkt.MeterValue() {
 						continue
 					}
 					lastValue[uint(pkt.MeterID())] = pkt.MeterValue()

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -130,6 +130,10 @@ func (scm SCM) MeterType() uint8 {
 	return scm.Type
 }
 
+func (scm SCM) MeterValue() uint32 {
+	return scm.Consumption
+}
+
 func (scm SCM) String() string {
 	return fmt.Sprintf("{ID:%8d Type:%2d Tamper:{Phy:%02X Enc:%02X} Consumption:%8d CRC:0x%04X}",
 		scm.ID, scm.Type, scm.TamperPhy, scm.TamperEnc, scm.Consumption, scm.Checksum,


### PR DESCRIPTION
I've added a option to suppress the printing of duplicate values.  This allows me to log the results of my meter without the log file growing huge because my meter is broadcasting the same value a dozen times or so.

This is my first crack at golang, so please review the change with that in mind.  The .gitignore change I didn't really mean to be in this; it's for vim and windows.

Note that my change does not work for IDM because I was unsure of the consumption value.  My particular meter is an SCM.