### PR TITLE
Add Itron 100WR

### DIFF
--- a/meters.csv
+++ b/meters.csv
@@ -47,6 +47,7 @@ http://fcc.io/EWQ100T,Itron,100T,Gas,9,903,926.9
 ,Itron,40GB,Gas,2,,
 http://fcc.io/EWQ100W,Itron,100W,Water,11,903,927
 ,Itron,100WP,Water,11,,
+,Itron,100WR,Water,171,,
 ,Itron,40W,Water,3,,
 ,Itron,50W,Water,3,,
 http://fcc.io/EO960W,Itron,60W,Water,13,910,919.8

--- a/meters.csv
+++ b/meters.csv
@@ -47,7 +47,7 @@ http://fcc.io/EWQ100T,Itron,100T,Gas,9,903,926.9
 ,Itron,40GB,Gas,2,,
 http://fcc.io/EWQ100W,Itron,100W,Water,11,903,927
 ,Itron,100WP,Water,11,,
-,Itron,100WR,Water,171,,
+,Itron,100WR,Water,11,,
 ,Itron,40W,Water,3,,
 ,Itron,50W,Water,3,,
 http://fcc.io/EO960W,Itron,60W,Water,13,910,919.8


### PR DESCRIPTION
When using SCM+ the 100WR has an id of  0xAB / 171

`{Time:2021-06-12T18:56:42.581 SCM+:{ProtocolID:0x1E EndpointType:0xAB EndpointID:  68731188 Consumption:     23792 Tamper:0x2500 PacketCRC:0xC8D2}}`

See bottom right corner of page 2 https://www.itron.com/-/media/feature/products/documents/spec-sheet/100w-water-endpoint-web-101020sp07.pdf