### PR TITLE
Neptune R900 full 8 digit consumption

### DIFF
--- a/r900/r900.go
+++ b/r900/r900.go
@@ -257,7 +257,7 @@ func (p *Parser) Parse(pkts []protocol.Data, msgCh chan protocol.Message, wg *sy
 type R900 struct {
 	ID          uint32 `xml:",attr"` // 32 bits
 	Unkn1       uint8  `xml:",attr"` // 4 bits
-        AmrType   uint8  `xml:",attr"` // 4 bits
+        AmrType     uint8  `xml:",attr"` // 4 bits
         Unkn2       uint8  `xml:",attr"` // 3 bits
 	NoUse       uint8  `xml:",attr"` // 3 bits, day bins of no use
 	BackFlow    uint8  `xml:",attr"` // 2 bits, backflow past 35d hi/lo

--- a/r900/r900.go
+++ b/r900/r900.go
@@ -284,7 +284,7 @@ func (r900 R900) Checksum() []byte {
 }
 
 func (r900 R900) String() string {
-	return fmt.Sprintf("{ID:%10d Unkn1:0x%02X MeterType:%02d Unkn2:0x%02X NoUse:%2d BackFlow:%1d Consumption:%8d Leak:%2d LeakNow:%1d}",
+	return fmt.Sprintf("{ID:%10d Unkn1:0x%1X MeterType:%02d Unkn2:0x%1X NoUse:%1d BackFlow:%1d Consumption:%8d Leak:%1d LeakNow:%1d}",
 		r900.ID,
 		r900.Unkn1,
 		r900.AmrType,


### PR DESCRIPTION
Prepended the consumption register high bits to allow full 8 digit reads.
Mapped the meter type field.
Reduced the nouse and leak fields to 3 bits as they were overflowing into adjacent fields.