### PR TITLE
Update meters.csv - AMR R300 from Schlumberger

### DIFF
--- a/meters.csv
+++ b/meters.csv
@@ -64,3 +64,4 @@ https://fcc.io/TEB-AIRPT677,Landis+Gyr,HP AirPoint,Electric,5,909.586,921.773
 https://fcc.io/TEB-AIRPT725,Landis+Gyr,HP AirPoint,Electric,5,909.586,921.773
 https://fcc.io/TEB-AIRPT657,Landis+Gyr,HP AirPoint I-210,Electric,5,909.586,921.773
 https://fcc.io/F9CC1C-3,Schlumberger,CENTRON OOK RF,Electric,12,917.58,917.58
+https://fccid.io/F9CR300-4,Schlumberger,AMR R300,Electric,4,910,920


### PR DESCRIPTION
All the writing on the meter besides the ID numbers:

Rr 27 7/9
CL200 240V 3W Type J5S 30TA 7.2Kh
AMR R300
FM2S 60Hz 
Schlumberger WATTHOUR METER